### PR TITLE
Fix: Map container is already initialized

### DIFF
--- a/offense_visualizer/visualizer.js
+++ b/offense_visualizer/visualizer.js
@@ -61,6 +61,7 @@ function reloadGraph()
 			// Added for OSM
 			var offenseIpMap = [];
 			var map = L.map('map');
+			map.remove();
 			map.locate({ setView: true, maxZoom:2 });
 
 			L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
When reloading map with leaflet, it must be removed before recreating it.
