### PR TITLE
Fix: Map container is already initialized

### DIFF
--- a/offense_visualizer/visualizer.js
+++ b/offense_visualizer/visualizer.js
@@ -60,6 +60,7 @@ function reloadGraph()
 
 			// Added for OSM
 			var offenseIpMap = [];
+			document.getElementById('mapTab').innerHTML = "<div id='map'></div>";
 			var map = L.map('map');
 			map.locate({ setView: true, maxZoom:2 });
 


### PR DESCRIPTION
Replaces #4... When reloading map with leaflet, it must be removed before recreating it.
