### PR TITLE
Fix: document.cookie SEC token

### DIFF
--- a/offense_visualizer/visualizer.js
+++ b/offense_visualizer/visualizer.js
@@ -33,7 +33,7 @@ function getValue( offense, attribute )
 
 function reloadGraph()
 {
- 	var token = document.cookie.split("; SEC=").pop().split(";").shift();
+ 	var token = document.cookie.split("SEC=").pop().split(";").shift();
 	var xhr = d3.xhr( "/restapi/api/siem/offenses" , "application/json");
 	
 	xhr.header('Accept', "application/json");


### PR DESCRIPTION
document.cookie may not contain another variable, so the split won't work fine with ";" before "SEC" string.
