### PR TITLE
Change CDN because of certificate issue

### DIFF
--- a/offense_visualizer/visualizer.html
+++ b/offense_visualizer/visualizer.html
@@ -23,11 +23,11 @@ specific language governing permissions and limitations under the License.
 <script src="d3.v3.min.js"></script>
 <script src="nv.d3.js"></script>
 
-<script src="//cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+<script src="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.js"></script>
 
 
 <script src="visualizer.js"></script>
-<link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.css" />
 <link href="nv.d3.css" rel="stylesheet">
 
 <style>


### PR DESCRIPTION
jsdelivr supports both HTTP and HTTPS protocols for loading CDN resources. Leafletjs' CDN only supports HTTP, so it will fail in QRadar when opening it using HTTPS. Fix for https://github.com/ibm-security-intelligence/visualizations/issues/1
